### PR TITLE
Update tauri-plugin-single-instance in order to fix dev:tauri on windows

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ fischl = { git = "https://github.com/TwintailTeam/fischl-rs.git", branch = "mast
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
-tauri-plugin-single-instance = "2"
+tauri-plugin-single-instance = "2.3.2"
 
 [profile.release]
 panic = "abort" # Strip expensive panic clean-up logic


### PR DESCRIPTION
This pull request updates the version of the `tauri-plugin-single-instance` dependency to ensure compatibility and stability.

Dependency update:

* Updated `tauri-plugin-single-instance` from an unspecified version `2` to the explicit version `2.3.2` in `src-tauri/Cargo.toml` for improved dependency management.

This also fixes a issue when trying to run `dev:tauri` on windows throwing the following error:

```
thread 'main' panicked at C:\Users\Minlor\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tauri-plugin-single-instance-2.2.0\src\platform_impl\windows.rs:121:34:
null pointer dereference occurred
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread caused non-unwinding panic. aborting.
error: process didn't exit successfully: `target\debug\twintaillauncher.exe` (exit code: 0xc0000409, STATUS_STACK_BUFFER_OVERRUN)
```