### PR TITLE
Bypass disk req. in case of existing installations, minor UI improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -380,9 +380,13 @@ export default class App extends React.Component<any, any> {
                 // @ts-ignore
                 let freedisk = document.getElementById("game_disk_free");
 
+                // Always enable button initially - the DownloadGame component will handle disabling based on checkbox state
+                // @ts-ignore
+                btn.removeAttribute("disabled");
+
+                // Set disk space styling based on available space (but don't disable button)
+
                 if (disk.game_decompressed_size_raw > disk.free_disk_space_raw) {
-                    // @ts-ignore
-                    btn.setAttribute("disabled", "");
                     // @ts-ignore
                     freedisk.classList.add("text-red-600");
                     // @ts-ignore
@@ -390,8 +394,6 @@ export default class App extends React.Component<any, any> {
                     // @ts-ignore
                     freedisk.classList.add("font-bold");
                 } else {
-                    // @ts-ignore
-                    btn.removeAttribute("disabled");
                     // @ts-ignore
                     freedisk.classList.remove("text-red-600");
                     // @ts-ignore

--- a/src/components/common/CheckBox.tsx
+++ b/src/components/common/CheckBox.tsx
@@ -2,7 +2,7 @@ import {useState} from "react";
 import {invoke} from "@tauri-apps/api/core";
 import HelpTooltip from "./HelpTooltip.tsx";
 
-export default function CheckBox({ id, name, enabled, install, fetchSettings, fetchInstallSettings, helpText}: { id: string, name: string, enabled: boolean, install?: string, fetchSettings?: () => void, fetchInstallSettings?: (id: string) => void, helpText: string }) {
+export default function CheckBox({ id, name, enabled, install, fetchSettings, fetchInstallSettings, helpText, onToggle}: { id: string, name: string, enabled: boolean, install?: string, fetchSettings?: () => void, fetchInstallSettings?: (id: string) => void, helpText: string, onToggle?: (checked: boolean) => void }) {
     const [isEnabled, setIsEnabled] = useState<boolean>(enabled);
 
     return (
@@ -24,6 +24,9 @@ export default function CheckBox({ id, name, enabled, install, fetchSettings, fe
                         break;
                         case "skip_game_dl": {
                             setIsEnabled(!isEnabled);
+                            if (onToggle) {
+                                onToggle(!isEnabled);
+                            }
                         }
                         break;
                         case "skip_version_updates": {

--- a/src/components/common/FolderInput.tsx
+++ b/src/components/common/FolderInput.tsx
@@ -29,7 +29,8 @@ interface IProps {
     version?: () => string,
     lang?: () => string,
     fetchDownloadSizes?: (biz: any, version: any, lang: any, path: any, callback: (data: any) => void) => void,
-    helpText: string
+    helpText: string,
+    skipGameDownload?: boolean
 }
 
 interface IState {
@@ -156,16 +157,8 @@ export default class FolderInput extends React.Component<IProps, IState> {
                         // @ts-ignore
                         let freedisk = document.getElementById("game_disk_free");
 
-                        if (disk.game_decompressed_size_raw > disk.free_disk_space_raw) {
-                            // @ts-ignore
-                            btn.setAttribute("disabled", "");
-                            // @ts-ignore
-                            freedisk.classList.add("text-red-600");
-                            // @ts-ignore
-                            freedisk.classList.remove("text-white");
-                            // @ts-ignore
-                            freedisk.classList.add("font-bold");
-                        } else {
+                        // Skip space validation if existing installation is selected
+                        if (this.props.skipGameDownload || disk.game_decompressed_size_raw <= disk.free_disk_space_raw) {
                             // @ts-ignore
                             btn.removeAttribute("disabled");
                             // @ts-ignore
@@ -174,6 +167,15 @@ export default class FolderInput extends React.Component<IProps, IState> {
                             freedisk.classList.add("text-white");
                             // @ts-ignore
                             freedisk.classList.remove("font-bold");
+                        } else {
+                            // @ts-ignore
+                            btn.setAttribute("disabled", "");
+                            // @ts-ignore
+                            freedisk.classList.add("text-red-600");
+                            // @ts-ignore
+                            freedisk.classList.remove("text-white");
+                            // @ts-ignore
+                            freedisk.classList.add("font-bold");
                         }
                     });
                 }

--- a/src/components/common/SelectMenu.tsx
+++ b/src/components/common/SelectMenu.tsx
@@ -3,7 +3,7 @@ import HelpTooltip from "./HelpTooltip.tsx";
 import {POPUPS} from "../popups/POPUPS.ts";
 
 
-export default function SelectMenu({ id, name, options, selected, multiple, install, biz, lang, version, dir, fetchInstallSettings, fetchSettings, fetchDownloadSizes, helpText, setOpenPopup}: { id: string, name: string, options: any, selected: any, multiple: boolean, install?: string, biz?: string, lang?: () => string, version?: () => any, dir?: () => string, helpText: string, fetchInstallSettings?: (id: string) => void, fetchSettings?: () => void, fetchDownloadSizes?: (biz: any, version: any, lang: any, dir: any, callback: (data: any) => void) => void, setOpenPopup: (popup: POPUPS) => void }) {
+export default function SelectMenu({ id, name, options, selected, multiple, install, biz, lang, version, dir, fetchInstallSettings, fetchSettings, fetchDownloadSizes, helpText, setOpenPopup, skipGameDownload}: { id: string, name: string, options: any, selected: any, multiple: boolean, install?: string, biz?: string, lang?: () => string, version?: () => any, dir?: () => string, helpText: string, fetchInstallSettings?: (id: string) => void, fetchSettings?: () => void, fetchDownloadSizes?: (biz: any, version: any, lang: any, dir: any, callback: (data: any) => void) => void, setOpenPopup: (popup: POPUPS) => void, skipGameDownload?: boolean }) {
     return (
         <div className="flex flex-row items-center justify-between w-full h-6">
             <span className="text-white text-sm flex items-center gap-1">{name}
@@ -20,16 +20,8 @@ export default function SelectMenu({ id, name, options, selected, multiple, inst
                                     // @ts-ignore
                                     let freedisk = document.getElementById("game_disk_free");
 
-                                    if (disk.game_decompressed_size_raw > disk.free_disk_space_raw) {
-                                        // @ts-ignore
-                                        btn.setAttribute("disabled", "");
-                                        // @ts-ignore
-                                        freedisk.classList.add("text-red-600");
-                                        // @ts-ignore
-                                        freedisk.classList.remove("text-white");
-                                        // @ts-ignore
-                                        freedisk.classList.add("font-bold");
-                                    } else {
+                                    // Skip space validation if existing installation is selected
+                                    if (skipGameDownload || disk.game_decompressed_size_raw <= disk.free_disk_space_raw) {
                                         // @ts-ignore
                                         btn.removeAttribute("disabled");
                                         // @ts-ignore
@@ -38,6 +30,15 @@ export default function SelectMenu({ id, name, options, selected, multiple, inst
                                         freedisk.classList.add("text-white");
                                         // @ts-ignore
                                         freedisk.classList.remove("font-bold");
+                                    } else {
+                                        // @ts-ignore
+                                        btn.setAttribute("disabled", "");
+                                        // @ts-ignore
+                                        freedisk.classList.add("text-red-600");
+                                        // @ts-ignore
+                                        freedisk.classList.remove("text-white");
+                                        // @ts-ignore
+                                        freedisk.classList.add("font-bold");
                                     }
                                 });
                             }
@@ -51,16 +52,8 @@ export default function SelectMenu({ id, name, options, selected, multiple, inst
                                     // @ts-ignore
                                     let freedisk = document.getElementById("game_disk_free");
 
-                                    if (disk.game_decompressed_size_raw > disk.free_disk_space_raw) {
-                                        // @ts-ignore
-                                        btn.setAttribute("disabled", "");
-                                        // @ts-ignore
-                                        freedisk.classList.add("text-red-600");
-                                        // @ts-ignore
-                                        freedisk.classList.remove("text-white");
-                                        // @ts-ignore
-                                        freedisk.classList.add("font-bold");
-                                    } else {
+                                    // Skip space validation if existing installation is selected
+                                    if (skipGameDownload || disk.game_decompressed_size_raw <= disk.free_disk_space_raw) {
                                         // @ts-ignore
                                         btn.removeAttribute("disabled");
                                         // @ts-ignore
@@ -69,6 +62,15 @@ export default function SelectMenu({ id, name, options, selected, multiple, inst
                                         freedisk.classList.add("text-white");
                                         // @ts-ignore
                                         freedisk.classList.remove("font-bold");
+                                    } else {
+                                        // @ts-ignore
+                                        btn.setAttribute("disabled", "");
+                                        // @ts-ignore
+                                        freedisk.classList.add("text-red-600");
+                                        // @ts-ignore
+                                        freedisk.classList.remove("text-white");
+                                        // @ts-ignore
+                                        freedisk.classList.add("font-bold");
                                     }
                                 });
                             }

--- a/src/components/popups/DownloadGame.tsx
+++ b/src/components/popups/DownloadGame.tsx
@@ -6,6 +6,7 @@ import TextDisplay from "../common/TextDisplay.tsx";
 import SelectMenu from "../common/SelectMenu.tsx";
 import {invoke} from "@tauri-apps/api/core";
 import {emit} from "@tauri-apps/api/event";
+import {useState, useEffect} from "react";
 
 interface IProps {
     icon: string,
@@ -25,6 +26,31 @@ interface IProps {
 }
 
 export default function DownloadGame({disk, setOpenPopup, displayName, settings, biz, versions, background, icon, pushInstalls, runnerVersions, dxvkVersions, setCurrentInstall, setBackground, fetchDownloadSizes}: IProps) {
+    const [skipGameDownload, setSkipGameDownload] = useState(false);
+
+    // Update button state when skipGameDownload changes
+    useEffect(() => {
+        const btn = document.getElementById("game_dl_btn");
+        const freedisk = document.getElementById("game_disk_free");
+
+        if (btn && freedisk) {
+            if (skipGameDownload) {
+                // Enable button and reset disk space styling when skipping download
+                btn.removeAttribute("disabled");
+                freedisk.classList.remove("text-red-600");
+                freedisk.classList.add("text-white");
+                freedisk.classList.remove("font-bold");
+            } else {
+                // Re-check disk space when not skipping download
+                if (disk && disk.game_decompressed_size_raw > disk.free_disk_space_raw) {
+                    btn.setAttribute("disabled", "");
+                    freedisk.classList.add("text-red-600");
+                    freedisk.classList.remove("text-white");
+                    freedisk.classList.add("font-bold");
+                }
+            }
+        }
+    }, [skipGameDownload, disk]);
 
     return (
         <div className="rounded-lg h-auto w-1/2 bg-black/50 fixed-backdrop-blur-md border border-white/20 flex flex-col p-4 gap-8 overflow-scroll scrollbar-none">
@@ -115,19 +141,19 @@ export default function DownloadGame({disk, setOpenPopup, displayName, settings,
                             console.error("Download error!");
                         }
                     });
-                }}><DownloadCloudIcon/><span className="font-semibold">Start download</span></button>
+                }}><DownloadCloudIcon/><span className="font-semibold">{skipGameDownload ? "Add existing installation" : "Start download"}</span></button>
             </div>
             <div className="w-full overflow-y-auto overflow-scroll scrollbar-none pr-4 -mr-4">
                 <div className="bg-black/20 border border-white/10 rounded-lg p-4 flex flex-col gap-4">
                     {/* @ts-ignore */}
-                    <FolderInput name={"Install location"} clearable={true} value={`${settings.default_game_path}/${biz}`} folder={true} id={"install_game_path"} biz={biz} fetchDownloadSizes={fetchDownloadSizes} version={getVersion} lang={getAudio} helpText={"Location where to download game files."}/>
-                    <CheckBox enabled={false} name={"Skip game download (Existing install)"} id={"skip_game_dl"} helpText={"This will skip downloading game files, useful if you already have game installed and just want to use that installation."}/>
+                    <FolderInput name={"Install location"} clearable={true} value={`${settings.default_game_path}/${biz}`} folder={true} id={"install_game_path"} biz={biz} fetchDownloadSizes={fetchDownloadSizes} version={getVersion} lang={getAudio} helpText={"Location where to download game files."} skipGameDownload={skipGameDownload}/>
+                    <CheckBox enabled={false} name={"Skip game download (Existing install)"} id={"skip_game_dl"} helpText={"This will skip downloading game files, useful if you already have game installed and just want to use that installation."} onToggle={setSkipGameDownload}/>
                     <CheckBox enabled={false} name={"Skip version update check"} id={"skip_version_updates"} helpText={"Skip checking for game updates."}/>
                     <CheckBox enabled={false} name={"Skip hash validation"} id={"skip_hash_validation"} helpText={"Skip validating files during game repair process, this will speed up the repair process significantly."}/>
                     <TextDisplay id={"game_disk_free"} name={"Available disk space"} value={`${disk.free_disk_space}`} style={"text-white px-3"}/>
                     <TextDisplay id={"game_disk_need"} name={"Required disk space (unpacked)"} value={`${disk.game_decompressed_size}`} style={"text-white px-3"}/>
-                    <SelectMenu id={"game_version"} name={"Game version"} options={versions} multiple={false} selected={""} biz={biz} dir={formatDir} fetchDownloadSizes={fetchDownloadSizes} lang={getAudio} helpText={"Version of the game to install."} setOpenPopup={setOpenPopup}/>
-                    <SelectMenu id={"game_audio_langs"} name={"Voice pack"} options={[{name: "English (US)", value: "en-us"}, {name: "Japanese", value: "ja-jp"}, {name: "Korean", value: "ko-kr"}, {name: "Chinese", value: "zh-cn"}]} multiple={false} selected={""} biz={biz} fetchDownloadSizes={fetchDownloadSizes} dir={formatDir} version={getVersion} helpText={"What audio package to install for the game."} setOpenPopup={setOpenPopup}/>
+                    <SelectMenu id={"game_version"} name={"Game version"} options={versions} multiple={false} selected={""} biz={biz} dir={formatDir} fetchDownloadSizes={fetchDownloadSizes} lang={getAudio} helpText={"Version of the game to install."} setOpenPopup={setOpenPopup} skipGameDownload={skipGameDownload}/>
+                    <SelectMenu id={"game_audio_langs"} name={"Voice pack"} options={[{name: "English (US)", value: "en-us"}, {name: "Japanese", value: "ja-jp"}, {name: "Korean", value: "ko-kr"}, {name: "Chinese", value: "zh-cn"}]} multiple={false} selected={""} biz={biz} fetchDownloadSizes={fetchDownloadSizes} dir={formatDir} version={getVersion} helpText={"What audio package to install for the game."} setOpenPopup={setOpenPopup} skipGameDownload={skipGameDownload}/>
                     {(window.navigator.platform.includes("Linux")) ? <SelectMenu id={"runner_version"} name={"Runner version"} multiple={false} options={runnerVersions} selected={runnerVersions[0].value} helpText={"Wine/Proton version to use for this installation."} setOpenPopup={setOpenPopup}/> : null}
                     {(window.navigator.platform.includes("Linux")) ? <SelectMenu id={"dxvk_version"} name={"DXVK version"} multiple={false} options={dxvkVersions} selected={dxvkVersions[0].value} helpText={"What DXVK version to use for this installation."} setOpenPopup={setOpenPopup}/> : null}
                     {(window.navigator.platform.includes("Linux")) ? <FolderInput name={"Runner prefix location"} clearable={true} value={`${settings.default_runner_prefix_path}/${biz}`} folder={true} id={"install_prefix_path"} helpText={"Location where to store Wine/Proton prefix."}/>: null}


### PR DESCRIPTION
This pull request enhances the handling of the "Skip game download (Existing install)" option in the game installation workflow. The main improvements are around allowing users to bypass disk space checks and UI restrictions when they indicate they already have the game installed, resulting in a more flexible and user-friendly experience.

Key changes include:

**Skip Game Download Logic & State Management**
- Added a `skipGameDownload` state in the `DownloadGame` popup, which is toggled by the "Skip game download" checkbox. This state is now propagated to child components (`FolderInput` and `SelectMenu`) to control their behavior. [[1]](diffhunk://#diff-bf2ab1118c52324861223487ee146a64f9e163c10e57bac7a53743bea6d0e171R29-R53)], [[2]](diffhunk://#diff-bf2ab1118c52324861223487ee146a64f9e163c10e57bac7a53743bea6d0e171L118-R156)])
- Updated the download button and disk space display to immediately reflect the user's choice to skip the download, enabling the button and resetting styling when skipping. ([[src/components/popups/DownloadGame.tsxR29-R53](diffhunk://#diff-bf2ab1118c52324861223487ee146a64f9e163c10e57bac7a53743bea6d0e171R29-R53)])

**Component Propagation & UI Consistency**
- Added a `skipGameDownload` prop to `FolderInput` and `SelectMenu` components, and updated their logic to bypass disk space validation and button disabling when this prop is set. [[1]](diffhunk://#diff-77650176a3bc03927914dfe58553d543408ad9867a7292c0662626646a7a07fdL32-R33)], [[2]](diffhunk://#diff-401de123d3202396246b2840adf26586fa2c2413e990cf4c2f85e103c5438806L6-R6)], [[3]](diffhunk://#diff-bf2ab1118c52324861223487ee146a64f9e163c10e57bac7a53743bea6d0e171L118-R156)])
- Updated the disk space validation logic in both `FolderInput` and `SelectMenu` to skip disabling the button and styling changes if `skipGameDownload` is true, ensuring consistent UI behavior. [[1]](diffhunk://#diff-77650176a3bc03927914dfe58553d543408ad9867a7292c0662626646a7a07fdL159-R178)], [[2]](diffhunk://#diff-401de123d3202396246b2840adf26586fa2c2413e990cf4c2f85e103c5438806L23-R41)], [[3]](diffhunk://#diff-401de123d3202396246b2840adf26586fa2c2413e990cf4c2f85e103c5438806L54-R73)])

**Checkbox Component Enhancement**
- Enhanced the `CheckBox` component to support an `onToggle` callback, allowing parent components to react to checkbox state changes. This is now used for the "Skip game download" checkbox to update the `skipGameDownload` state in `DownloadGame`. [[1]](diffhunk://#diff-8bd9fef42bf5438f7b0f1d72b30e4da31a6316b4a52a0f0b03dca69e52172641L5-R5)], [[2]](diffhunk://#diff-8bd9fef42bf5438f7b0f1d72b30e4da31a6316b4a52a0f0b03dca69e52172641R27-R29)], [[3]](diffhunk://#diff-bf2ab1118c52324861223487ee146a64f9e163c10e57bac7a53743bea6d0e171L118-R156)])

**UI/UX Improvements**
- Changed the download button label to "Add existing installation" when skipping the download, improving clarity for users. ([[src/components/popups/DownloadGame.tsxL118-R156](diffhunk://#diff-bf2ab1118c52324861223487ee146a64f9e163c10e57bac7a53743bea6d0e171L118-R156)])
- Ensured the download button is always enabled initially, with state managed by the `DownloadGame` component and its children, rather than being directly disabled based on disk space in the parent. ([[src/App.tsxL383-L394](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L383-L394)])

These changes collectively make the installation process more robust and user-friendly, especially for users who already have the game files and want to register an existing installation.

This PR also closes issue #60 