### PR TITLE
Add timeout on preload

### DIFF
--- a/src/services/loader.ts
+++ b/src/services/loader.ts
@@ -3,6 +3,8 @@ import { listen } from "@tauri-apps/api/event";
 import { Events } from "../constants/events.ts";
 import { registerEvents } from "./events.ts";
 
+const IMAGE_PRELOAD_TIMEOUT_MS = 30000;
+
 export type SetProgressFn = (progress: number, message: string) => void;
 
 export interface LoaderOptions {
@@ -76,15 +78,30 @@ export function startInitialLoad(opts: LoaderOptions): LoaderController {
       const installBackgrounds: string[] = installs.map((i: any) => i?.game_background).filter(Boolean);
       const installIcons: string[] = installs.map((i: any) => i?.game_icon).filter(Boolean);
       const images = Array.from(new Set([/*...(gameLiveBackgrounds as string[]), */...(gameBackgrounds as string[]), ...(gameIcons as string[]), ...(installBackgrounds as string[]), ...(installIcons as string[])]));
-      await opts.preloadImages(
-        images,
-        (loaded, total) => {
-          if (cancelled) return;
-          const progress = 75 + Math.round((loaded / total) * 25);
-          opts.setProgress(progress, `Preloading images... (${loaded}/${total})`);
-        },
-        opts.preloadedBackgrounds
-      );
+      try {
+        await Promise.race([
+          // original preload call
+          opts.preloadImages(
+            images,
+            (loaded, total) => {
+              if (cancelled) return;
+              const progress = 75 + Math.round((loaded / total) * 25);
+              opts.setProgress(progress, `Preloading images... (${loaded}/${total})`);
+            },
+            opts.preloadedBackgrounds
+          ),
+          // timeout
+          new Promise<void>((resolve) => {
+            setTimeout(() => {
+              console.warn(`Image preloading did not finish within ${IMAGE_PRELOAD_TIMEOUT_MS}ms, continuing startup.`);
+              resolve();
+            }, IMAGE_PRELOAD_TIMEOUT_MS);
+          }),
+        ]);
+      } catch (e) {
+        console.error("Error during image preloading:", e);
+      }
+
       if (cancelled) return;
       opts.setProgress(100, "Almost ready...");
 


### PR DESCRIPTION
Add a timeout around the initial image preload step so the launcher no longer gets stuck on “Preloading images…” when some CDNs are slow or unreachable.

The loader now wraps preloadImages in a Promise.race with a 30s timeout:
- If all images preload successfully within the timeout, behavior is unchanged.
- If the timeout is hit, a warning is logged and startup continues instead of blocking indefinitely.