### PR TITLE
fix(i18n): initialize locales before startup translations and fix region formatting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -916,7 +916,8 @@ export default class App extends React.Component<any, any> {
                 this.setState(() => ({
                     globalSettings: gs
                 }));
-                this.fetchLocales(gs?.app_lang);
+                return this.fetchLocales(gs?.app_lang);
+                // Wait until locales loaded then return
             }
         });
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -908,18 +908,17 @@ export default class App extends React.Component<any, any> {
         })
     }
 
-    fetchSettings() {
-        return invoke<any | null>("list_settings").then(gs => {
-            if (gs === null) {
-                console.error("Settings database table contains nothing, some serious fuck up happened!")
-            } else {
-                this.setState(() => ({
-                    globalSettings: gs
-                }));
-                return this.fetchLocales(gs?.app_lang);
-                // Wait until locales loaded then return
-            }
-        });
+    async fetchSettings() {
+        // Use async to await locales loaded
+        const gs = await invoke<any | null>("list_settings");
+        if (gs === null) {
+            console.error("Settings database table contains nothing, some serious fuck up happened!");
+        } else {
+            this.setState(() => ({
+                globalSettings: gs
+            }));
+            await this.fetchLocales(gs?.app_lang);
+        }
     }
 
     fetchLocales(appLang?: string) {

--- a/src/components/layout/PlayStatsOverlay.tsx
+++ b/src/components/layout/PlayStatsOverlay.tsx
@@ -25,7 +25,7 @@ function formatLastPlayed(value?: string | number, appLang?: string): string {
     if (dayDiff === 0) return translate("play_stats.today");
     if (dayDiff === 1) return translate("play_stats.yesterday");
 
-    const intlLocale = appLang ? appLang.replace("_", "-") : undefined;
+    const intlLocale = appLang ? appLang.replace(/_/g, "-") : undefined;
     return date.toLocaleDateString(intlLocale, {
         month: "short",
         day: "numeric",

--- a/src/services/loader.ts
+++ b/src/services/loader.ts
@@ -102,8 +102,14 @@ export function startInitialLoad(opts: LoaderOptions): LoaderController {
       if (cancelled) return;
 
       // Load settings and locales immediately — local DB, no network needed
-      opts.fetchSettings().catch(e => console.error("Error loading settings:", e));
+      // Trying to use await to load locales before translate() is used below
+      try {
+        await opts.fetchSettings();
+      } catch (e) {
+        console.error("Error loading settings:", e);
+      }
 
+      if (cancelled) return;
       opts.setProgress(0, translate("network.checking"));
 
       // Step 0: Network connectivity check with retry support


### PR DESCRIPTION
fix(i18n): initialize locales before startup translations and fix region formatting

Fixing TwintailTeam/TwintailLauncher#267:
- The Key name "network.checking" exposed during APP launches, and dont show any translated text. To solve it, i tried to use await method to wait settings and locale loading before the initial loader calls translate(). 
position: /src/services/loader.ts: 105-112
- And i discovered only above is not enough,so return the fetchLocales() promise from fetchSettings() ,then callers can wait for setTranslations() to complete
position: /src/app.tsx: 919-920

Related to Pull Request pull#265:
- Also fixing Regex to normalize internal locale codes before passing them to Intl date formatting, converting values such as zh_Hans_CN to zh-Hans-CN to avoid RangeError crashes in PlayStatsOverlay. 
position: /src/components/layout/PlayStatsOverlay.tsx: 28