### PR TITLE
Fix DW runner detection for nested paths

### DIFF
--- a/src-tauri/src/utils/game_launch_manager.rs
+++ b/src-tauri/src/utils/game_launch_manager.rs
@@ -49,10 +49,16 @@ pub fn launch<R: Runtime>(app: &AppHandle<R>, install: LauncherInstall, gm: Game
     }
 
     // Hate this as much as users will but dw runners do not support modding
-    if install.use_xxmi && (runner.to_lowercase().contains("dw") || crate::utils::get_steam_tool_name(runnerpi.clone()).to_lowercase().contains("dw")) {
-        log::info!("Attempted to launch {} with blacklisted runner (Runner: {})! Please do not use this runner.", install.name, install.runner_version);
-        show_dialog_with_callback(app, "error", "TwintailLauncher", "dialogs.launch_cmd_failed", Some(vec!["dialogs.buttons.i_understand"]), None, Some(std::collections::HashMap::from([("install_name", install.name.as_str())])));
-        return Ok(false);
+    if install.use_xxmi {
+        let runner_last = runnerpi
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+        if runner_last.to_lowercase().contains("dw") || crate::utils::get_steam_tool_name(runnerpi.clone()).to_lowercase().contains("dw") {
+            log::info!("Attempted to launch {} with blacklisted runner (Runner: {})! Please do not use this runner.", install.name, install.runner_version);
+            show_dialog_with_callback(app, "error", "TwintailLauncher", "dialogs.launch_cmd_failed", Some(vec!["dialogs.buttons.i_understand"]), None, Some(std::collections::HashMap::from([("install_name", install.name.as_str())])));
+            return Ok(false);
+        }
     }
 
     if is_runner_lower(cpo.min_runner_versions.clone(), install.clone().runner_version) && !cpo.min_runner_versions.is_empty() {
@@ -753,3 +759,4 @@ fn start_playtime_tracker<R: Runtime>(app: &AppHandle<R>, install: LauncherInsta
         }
     });
 }
+


### PR DESCRIPTION
## Fix runner blacklist check for full paths

This PR fixes an issue where the runner blacklist check incorrectly matched against the full runner path.

`runnerpi` contains the full path to the runner. For example, with my username `mvdw`, the path may look like:

```text
/home/mvdw/...
```

Because the previous check searched the entire path for `"dw"`, it incorrectly detected `mvdw` in the home directory as a blacklisted runner. As a result, GIMI could not be launched.

### Fix

The blacklist check now extracts only the last part of the runner's path before checking for the blacklisted name. This prevents the user's home directory or other parts of the path from affecting the check.
